### PR TITLE
Invalid SQL is executed on rails 2.3.10

### DIFF
--- a/spec/searchlogic/active_record/association_proxy_spec.rb
+++ b/spec/searchlogic/active_record/association_proxy_spec.rb
@@ -6,18 +6,25 @@ describe "Searchlogic::ActiveRecord::AssociationProxy" do
     user = company.users.create(:username => "bjohnson")
     company.users.send(:username_like, "bjohnson").should == [user]
   end
-  
+
+  it "should call location conditions with named_scope" do
+    company = Company.create
+    user = company.users.create(:username => "bjohnson")
+    company2 = Company.create
+    other_com_user = company2.users.create(:username => "bob")
+    company.users.username_containing_the_letter_b.username_like("o").should == [user]
+  end
+
   it "should call ordering conditions" do
     company = Company.create
     user = company.users.create(:username => "bjohnson")
     company.users.send(:ascend_by_username).should == [user]
   end
-  
+
   it "should call 'or' conditions" do
     company = Company.create
     user = company.users.create(:username => "bjohnson")
     company.users.send(:username_or_some_type_id_like, "bjohnson").should == [user]
   end
-    
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,6 +101,8 @@ Spec::Runner.configure do |config|
       has_many :orders_big, :class_name => 'Order', :conditions => 'total > 100'
       has_and_belongs_to_many :user_groups
 
+      named_scope :username_containing_the_letter_b, { :conditions => "username LIKE '%b%'" }
+
       self.skip_time_zone_conversion_for_attributes = [:whatever_at]
     end
 


### PR DESCRIPTION
https://rails.lighthouseapp.com/projects/8994/tickets/4634-duplicate-association-conditions-are-generated-when-using-a-named_scope-on-an-association

On Rails 2.3.10, this ticket's commit is included. Invalid SQL is executed to work with searchlogic.
http://gist.github.com/632095

We got critical trouble by this bug on production environment.

I don't have idea to resolve it. but, I recommend not to use Rails 2.3.10 with searchlogic until it is resolved.
