### PR TITLE
Fix NameError when ordering using polymorphic association

### DIFF
--- a/lib/searchlogic/named_scopes/association_ordering.rb
+++ b/lib/searchlogic/named_scopes/association_ordering.rb
@@ -37,7 +37,14 @@ module Searchlogic
         end
         
         def create_association_ordering_condition(association, order_as, condition, args)
-          named_scope("#{order_as}_by_#{association.name}_#{condition}", association_condition_options(association, "#{order_as}_by_#{condition}", args))
+         cond = condition
+         poly_class = nil
+         if condition =~ /^(\w+)_type_(\w+)$/
+           poly_type = $1
+           cond = $2
+           poly_class = poly_type.camelcase.constantize if poly_type
+         end
+         named_scope("#{order_as}_by_#{association.name}_#{condition}", association_condition_options(association, "#{order_as}_by_#{cond}", args, poly_class))
         end
     end
   end

--- a/spec/searchlogic/named_scopes/association_ordering_spec.rb
+++ b/spec/searchlogic/named_scopes/association_ordering_spec.rb
@@ -24,4 +24,8 @@ describe Searchlogic::NamedScopes::Ordering do
   it "should work through #order" do
     Company.order('ascend_by_users_username').proxy_options.should == Company.ascend_by_users_username.proxy_options
   end
+  
+  it "should ascend with a polymorphic belongs to" do
+    Audit.ascend_by_auditable_user_type_username.proxy_options.should == User.descend_by_username.proxy_options.merge(:joins => :users)
+  end
 end

--- a/spec/searchlogic/named_scopes/association_ordering_spec.rb
+++ b/spec/searchlogic/named_scopes/association_ordering_spec.rb
@@ -26,6 +26,6 @@ describe Searchlogic::NamedScopes::Ordering do
   end
   
   it "should ascend with a polymorphic belongs to" do
-    Audit.ascend_by_auditable_user_type_username.proxy_options.should == User.descend_by_username.proxy_options.merge(:joins => :users)
+    Audit.descend_by_auditable_user_type_username.proxy_options.should == User.descend_by_username.proxy_options.merge(:joins => :users)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,6 +99,7 @@ Spec::Runner.configure do |config|
       belongs_to :company, :counter_cache => true
       has_many :orders, :dependent => :destroy
       has_many :orders_big, :class_name => 'Order', :conditions => 'total > 100'
+      has_many :audits, :as => :auditable
       has_and_belongs_to_many :user_groups
 
       self.skip_time_zone_conversion_for_attributes = [:whatever_at]


### PR DESCRIPTION
In my application I have the following models:

```
User.belongs_to :profile, :polymorphic => true
Empresa.has_many :users, :as => :profile
```

When I tried to do the sorting through the polymorphic association, resulted in an error because the sorting method was not taking into account the type of association.

```
User.ascend_by_profile_empresa_type_nome.proxy_options
```

I get the following error:

```
> NameError: uninitialized constant User::Profile
```
