### PR TITLE
Failing test case for a bug with association conditions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source :rubygems
+
+gem 'jeweler'
+
+gem 'activerecord', '>= 2.0.0'
+
+group :test do
+  gem 'rspec', '1.3.1'
+  gem 'sqlite3-ruby'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
 require 'rubygems'
 require 'rake'
+require 'bundler'
+
+Bundler.setup
 
 begin
   require 'jeweler'
@@ -11,7 +14,7 @@ begin
     gem.homepage = "http://github.com/binarylogic/searchlogic"
     gem.authors = ["Ben Johnson of Binary Logic"]
     gem.rubyforge_project = "searchlogic"
-    gem.add_dependency "activerecord", ">= 2.0.0"
+    gem.add_bundler_dependencies
   end
   Jeweler::GemcutterTasks.new
 rescue LoadError
@@ -29,7 +32,5 @@ Spec::Rake::SpecTask.new(:rcov) do |spec|
   spec.pattern = 'spec/**/*_spec.rb'
   spec.rcov = true
 end
-
-task :spec => :check_dependencies
 
 task :default => :spec

--- a/spec/searchlogic/named_scopes/association_conditions_spec.rb
+++ b/spec/searchlogic/named_scopes/association_conditions_spec.rb
@@ -200,4 +200,16 @@ describe Searchlogic::NamedScopes::AssociationConditions do
     
     Company.users_id_equals_any([user2.id, user3.id]).all(:select => "DISTINCT companies.*").should == [company2]
   end
+  
+  it "should not lose association conditions on bizarre occasions" do
+    pending
+    user = User.create
+    order = Order.create :user => user, :shipped_on => Time.now
+    order.line_items.create :price => 37
+    order = Order.create :shipped_on => Time.now
+    order.line_items.create :price => 37
+    user.orders.shipped_on_not_null # this line causes the test to fail
+    user.orders.shipped_on_not_null.line_items_price_eq(37).count.should == 1
+  end
+
 end

--- a/spec/searchlogic/named_scopes/association_conditions_spec.rb
+++ b/spec/searchlogic/named_scopes/association_conditions_spec.rb
@@ -158,7 +158,7 @@ describe Searchlogic::NamedScopes::AssociationConditions do
     User.named_scope(:orders_big_id, :joins => User.inner_joins(:orders))
     Company.users_orders_big_id.proxy_options.should == {:joins=>[" INNER JOIN \"users\" ON users.company_id = companies.id ", " INNER JOIN \"orders\" ON orders.user_id = users.id "]}
   end
-
+  
   it "should order the join statements ascending by the fieldnames so that we don't get double joins where the only difference is that the order of the fields is different" do
     company = Company.create
     user = company.users.create(:company_id => company.id)
@@ -201,15 +201,14 @@ describe Searchlogic::NamedScopes::AssociationConditions do
     Company.users_id_equals_any([user2.id, user3.id]).all(:select => "DISTINCT companies.*").should == [company2]
   end
   
-  it "should not lose association conditions on bizarre occasions" do
+  it "should allow dynamic scope generation on associations without losing association scope options" do
     pending
     user = User.create
-    order = Order.create :user => user, :shipped_on => Time.now
-    order.line_items.create :price => 37
-    order = Order.create :shipped_on => Time.now
-    order.line_items.create :price => 37
-    user.orders.shipped_on_not_null # this line causes the test to fail
-    user.orders.shipped_on_not_null.line_items_price_eq(37).count.should == 1
+    Order.create :user => user, :shipped_on => Time.now
+    Order.create :shipped_on => Time.now
+    # The next line causes the assertion to fail
+    Order.named_scope :shipped_on_not_null, :conditions => ['shipped_on is not null']
+    user.orders.shipped_on_not_null.shipped_on_greater_than(2.days.ago).count.should == 1
   end
 
 end


### PR DESCRIPTION
Hi,

First of all, thanks a lot for this great gem.
I've encountered a bug seemingly related to scope caching ; the association conditions are dropped on certain occasions. I've written a failing test case that is exhibiting the bug.
I've also taken the liberty to write a Gemfile specifying the dependencies needed to work on the gem, as I've had quite a hard time figuring out the correct values (especially the version needed for spec).
Can you please let me know if there's a chance that this bug can be easily and promptly fixed by you ?
Thanks in advance
