### PR TITLE
SearchLogic should not be initialized for abstract AR classes

### DIFF
--- a/lib/searchlogic/named_scopes/column_conditions.rb
+++ b/lib/searchlogic/named_scopes/column_conditions.rb
@@ -60,7 +60,7 @@ module Searchlogic
       # We want to return true for any conditions that can be called, and while we're at it. We might as well
       # create the condition so we don't have to do it again.
       def respond_to?(*args)
-        super || (self != ::ActiveRecord::Base && !create_condition(args.first).blank?)
+        super || (self != ::ActiveRecord::Base && !self.abstract_class? && !create_condition(args.first).blank?)
       end
 
       private


### PR DESCRIPTION
Abstract AR-Classes have no table and should not be initialized.
