### PR TITLE
reference self rather than top level AR base to determine object connection adapter

### DIFF
--- a/lib/searchlogic/named_scopes/column_conditions.rb
+++ b/lib/searchlogic/named_scopes/column_conditions.rb
@@ -113,7 +113,7 @@ module Searchlogic
           column = columns_hash[column_name.to_s]
           column_type = column.type
           skip_conversion = skip_time_zone_conversion_for_attributes.include?(column.name.to_sym)
-          match_keyword = ::ActiveRecord::Base.connection.adapter_name == "PostgreSQL" ? "ILIKE" : "LIKE"
+          match_keyword = self.connection.adapter_name == "PostgreSQL" ? "ILIKE" : "LIKE"
 
           scope_options = case condition.to_s
           when /^equals/


### PR DESCRIPTION
This is needed in multi-db environments when different databases are used.

I have multi-db environment.  One is postgres the other db's are firebird.  Using 'self' here results in search correctly identifying postgres as the adapter.
