### PR TITLE
Allow Marshal.dump on objects that only have polymorphic associations where a polymorphic association is loaded

### DIFF
--- a/lib/searchlogic/named_scopes/association_conditions.rb
+++ b/lib/searchlogic/named_scopes/association_conditions.rb
@@ -32,7 +32,7 @@ module Searchlogic
           poly_type = nil
           condition = nil
 
-          if name_with_condition.to_s =~ /^(#{non_poly_assocs.collect(&:name).join("|")})_(\w+)$/
+          if name_with_condition.to_s =~ /^(#{non_poly_assocs.collect(&:name).join("|")})_(\w+)$/ && non_poly_assocs.present?
             association_name = $1
             condition = $2
           elsif name_with_condition.to_s =~ /^(#{poly_assocs.collect(&:name).join("|")})_(\w+?)_type_(\w+)$/

--- a/spec/searchlogic/named_scopes/association_conditions_spec.rb
+++ b/spec/searchlogic/named_scopes/association_conditions_spec.rb
@@ -217,4 +217,10 @@ describe Searchlogic::NamedScopes::AssociationConditions do
     user.orders.id_equals(order1.id).count.should == 1
     user.orders.id_equals(order1.id).total_equals(2).count.should == 1
   end
+
+  it "should allow Marshal.dump on objects that only have polymorphic associations where a polymorphic association is loaded" do
+    audit = Audit.create
+    audit.auditable = User.create
+    lambda { Marshal.dump(audit) }.should_not raise_error
+  end
 end


### PR DESCRIPTION
Was incorrectly matching to _dump
