### PR TITLE
remove arity == 0 check so that chained scopes aren't cached

### DIFF
--- a/lib/searchlogic/named_scopes/association_conditions.rb
+++ b/lib/searchlogic/named_scopes/association_conditions.rb
@@ -62,7 +62,7 @@ module Searchlogic
           raise ArgumentError.new("The #{klass} class does not respond to the #{association_condition} scope") if !klass.respond_to?(association_condition)
           arity = klass.named_scope_arity(association_condition)
 
-          if !arity || arity == 0
+          if !arity
             # The underlying condition doesn't require any parameters, so let's just create a simple
             # named scope that is based on a hash.
             options = {}


### PR DESCRIPTION
remove arity == 0 check so that chained scopes aren't cached (https://rails.lighthouseapp.com/projects/8994/tickets/4960-scopes-cached-in-production-mode#ticket-4960-6)
